### PR TITLE
Don't include protos (and some other dependencies) in jars

### DIFF
--- a/publish/BUILD.bazel
+++ b/publish/BUILD.bazel
@@ -75,6 +75,9 @@ java_export(
     maven_coordinates = "dev.cel:cel:%s" % CEL_VERSION,
     pom_template = ":cel_pom",
     runtime_deps = ALL_TARGETS,
+    deploy_env = [
+        "@com_google_googleapis//google/api/expr/v1alpha1:expr_java_proto"
+    ],
 )
 
 pom_file(

--- a/publish/BUILD.bazel
+++ b/publish/BUILD.bazel
@@ -72,12 +72,12 @@ pom_file(
 
 java_export(
     name = "cel",
-    maven_coordinates = "dev.cel:cel:%s" % CEL_VERSION,
-    pom_template = ":cel_pom",
-    runtime_deps = ALL_TARGETS,
     deploy_env = [
         "@com_google_googleapis//google/api/expr/v1alpha1:expr_java_proto"
     ],
+    maven_coordinates = "dev.cel:cel:%s" % CEL_VERSION,
+    pom_template = ":cel_pom",
+    runtime_deps = ALL_TARGETS,
 )
 
 pom_file(
@@ -94,6 +94,9 @@ pom_file(
 
 java_export(
     name = "cel_compiler",
+    deploy_env = [
+        "@com_google_googleapis//google/api/expr/v1alpha1:expr_java_proto"
+    ],
     maven_coordinates = "dev.cel:compiler:%s" % CEL_VERSION,
     pom_template = ":cel_compiler_pom",
     runtime_deps = COMPILER_TARGETS,
@@ -113,6 +116,9 @@ pom_file(
 
 java_export(
     name = "cel_runtime",
+    deploy_env = [
+        "@com_google_googleapis//google/api/expr/v1alpha1:expr_java_proto"
+    ],
     maven_coordinates = "dev.cel:runtime:%s" % CEL_VERSION,
     pom_template = ":cel_runtime_pom",
     runtime_deps = RUNTIME_TARGETS,
@@ -132,6 +138,9 @@ pom_file(
 
 java_export(
     name = "cel_extensions",
+    deploy_env = [
+        "@com_google_googleapis//google/api/expr/v1alpha1:expr_java_proto"
+    ],
     maven_coordinates = "dev.cel:extensions:%s" % CEL_VERSION,
     pom_template = ":cel_extensions_pom",
     runtime_deps = EXTENSION_TARGETS,
@@ -151,6 +160,9 @@ pom_file(
 
 java_export(
     name = "cel_validators",
+    deploy_env = [
+        "@com_google_googleapis//google/api/expr/v1alpha1:expr_java_proto"
+    ],
     maven_coordinates = "dev.cel:validators:%s" % CEL_VERSION,
     pom_template = ":cel_validators_pom",
     runtime_deps = VALIDATOR_TARGETS,
@@ -170,6 +182,9 @@ pom_file(
 
 java_export(
     name = "cel_optimizers",
+    deploy_env = [
+        "@com_google_googleapis//google/api/expr/v1alpha1:expr_java_proto"
+    ],
     maven_coordinates = "dev.cel:optimizers:%s" % CEL_VERSION,
     pom_template = ":cel_optimizers_pom",
     runtime_deps = OPTIMIZER_TARGETS,
@@ -189,6 +204,9 @@ pom_file(
 
 java_export(
     name = "cel_v1alpha1",
+    deploy_env = [
+        "@com_google_googleapis//google/api/expr/v1alpha1:expr_java_proto"
+    ],
     maven_coordinates = "dev.cel:v1alpha1:%s" % CEL_VERSION,
     pom_template = ":cel_v1alpha1_pom",
     runtime_deps = V1ALPHA1_UTILITY_TARGETS,


### PR DESCRIPTION
The cel target in `publish` does not exclude the `googleapis` protobufs and so the generated classes get included in the jar. Some other stuff like `com.google.rpc.Status` also get pulled in. This causes problems when trying to use the maven central artifact in builds that include the googleapis artifacts from maven central.

With this change, only `dev.cel.*` and `cel.*` classes are included in the artifact.