### PR TITLE
Add link to Protocol Buffers tutorials in codelab README.md

### DIFF
--- a/codelab/README.md
+++ b/codelab/README.md
@@ -20,7 +20,7 @@ Some key areas covered are:
 ### Prerequisites
 This codelab builds upon a basic understanding of Protocol Buffers and Java.
 
-If you're not familiar with Protocol Buffers, the first exercise will give you a sense of how CEL works, but because the more advanced examples use Protocol Buffers as the input into CEL, they may be harder to understand. Consider working through one of these tutorials, first.
+If you're not familiar with Protocol Buffers, the first exercise will give you a sense of how CEL works, but because the more advanced examples use Protocol Buffers as the input into CEL, they may be harder to understand. Consider working through one of these [tutorials](https://developers.google.com/protocol-buffers/docs/tutorials?authuser=0), first.
 
 Note that Protocol Buffers are not required to use CEL, but they are used extensively in this codelab.
 


### PR DESCRIPTION
Add the same Protocol Buffers tutorials link as used in [CEL-Go Codelab Introduction's Prerequisites](https://codelabs.developers.google.com/codelabs/cel-go#0)

![image](https://github.com/google/cel-java/assets/24294369/84bb9c71-cf0b-4f82-99ee-184c57d54dc5)
