### PR TITLE
Prepare 0.3.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CEL-Java is available in Maven Central Repository. [Download the JARs here][8] o
 <dependency>
   <groupId>dev.cel</groupId>
   <artifactId>cel</artifactId>
-  <version>0.3.0</version>
+  <version>0.3.1</version>
 </dependency>
 ```
 

--- a/publish/cel_version.bzl
+++ b/publish/cel_version.bzl
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Maven artifact version for CEL."""
-CEL_VERSION = "0.3.0"
+CEL_VERSION = "0.3.1"


### PR DESCRIPTION
Documentation only change. Actual changes going to maven central is https://github.com/google/cel-java/tree/release/0.3.1-cherry-picked