### PR TITLE
Fix math.round to use HALF_UP to match doc, cel-go/cel-cpp

### DIFF
--- a/extensions/src/main/java/dev/cel/extensions/CelMathExtensions.java
+++ b/extensions/src/main/java/dev/cel/extensions/CelMathExtensions.java
@@ -874,7 +874,7 @@ public final class CelMathExtensions
     if (isNaN(x) || isInfinite(x)) {
       return x;
     }
-    return DoubleMath.roundToLong(x, RoundingMode.HALF_EVEN);
+    return DoubleMath.roundToLong(x, RoundingMode.HALF_UP);
   }
 
   private static Number sign(Number x) {

--- a/extensions/src/test/java/dev/cel/extensions/CelMathExtensionsTest.java
+++ b/extensions/src/test/java/dev/cel/extensions/CelMathExtensionsTest.java
@@ -735,6 +735,13 @@ public class CelMathExtensionsTest {
   @TestParameters("{expr: 'math.round(-1.5)' , expectedResult: -2.0}")
   @TestParameters("{expr: 'math.round(-1.2)' , expectedResult: -1.0}")
   @TestParameters("{expr: 'math.round(-1.6)' , expectedResult: -2.0}")
+  // Discriminating tie cases: confirm "ties round away from zero" (HALF_UP), not
+  // banker's rounding (HALF_EVEN).  1.5/-1.5 above don't distingish the two because
+  // their nearest-even neighbor (2/-2) is also the away-from-zero neighbor.
+  @TestParameters("{expr: 'math.round(0.5)' , expectedResult: 1.0}")
+  @TestParameters("{expr: 'math.round(2.5)' , expectedResult: 3.0}")
+  @TestParameters("{expr: 'math.round(-0.5)' , expectedResult: -1.0}")
+  @TestParameters("{expr: 'math.round(-2.5)' , expectedResult: -3.0}")
   @TestParameters("{expr: 'math.round(0.0/0.0)' , expectedResult: NaN}")
   @TestParameters("{expr: 'math.round(1.0/0.0)' , expectedResult: Infinity}")
   @TestParameters("{expr: 'math.round(-1.0/0.0)' , expectedResult: -Infinity}")


### PR DESCRIPTION
## Summary                                                                                                                                                                            
  - `math.round` uses `HALF_EVEN` (banker's rounding) internally, but cel-java's own function declaration, cel-go's reference implementation, and cel-cpp's reference implementation all specify "ties round away from zero". cel-java is the outlier among the three official reference clients; this PR brings it into alignment by switching the binding to `HALF_UP`.                                                                                                                               
  - Add four discriminating tie test cases (`±0.5`, `±2.5`). The existing tie cases `±1.5` round to `±2` under both `HALF_UP` and `HALF_EVEN` and so could not catch the bug.                                                                                                                                                            
                                                                       
  ## Cross-implementation status                                                                                                                                                        
                                                                       
  | Client | Implementation | Spec/stdlib contract | Suite probes a discriminating tie? |                                                                                               
  |---|---|---|---|
  | **cel-go** | `math.Round(float64(v))` at `ext/math.go:629` | Go stdlib: "rounding half **away from zero**" | No (covers `1.5/-1.5` only) |                                          
  | **cel-cpp** | `std::round(value)` at `math_ext.cc:204` | C++ standard: "halfway cases **away from zero**, regardless of the current rounding mode" | **Yes** — `math.round(42.5) == 43.0` at `math_ext_test.cc:552` |                                                                                                                                                     
  | **cel-java** (this PR, before) | `DoubleMath.roundToLong(x, HALF_EVEN)` at `CelMathExtensions.java:877` | Docstring at L407: "ties rounding away from zero" — but binding does banker's | No (covers `1.5/-1.5` only) |                                                                                                                                              
  | **cel-java** (this PR, after) | `DoubleMath.roundToLong(x, HALF_UP)` | Matches docstring + cel-go + cel-cpp | **Yes** — four new tie cases added below |
                                                                                                                                                                                        
  cel-cpp's test `math.round(42.5) == 43.0` is the canonical discriminator: under `HALF_EVEN` it would round to `42` (since 42 is even) and the test would fail. cel-cpp's suite would catch this bug today; cel-java's and cel-go's                                                                                                             
  suites would not — both probe only `±1.5`, which rounds to `±2` under either mode.                                                                                                                                                                                 
                                                                                                                                                                                        
                                                                                          
