### PR TITLE
Handle FIXED32/FIXED64 as unsigned in ProtoCelValueConverter

### DIFF
--- a/common/src/main/java/dev/cel/common/values/ProtoCelValueConverter.java
+++ b/common/src/main/java/dev/cel/common/values/ProtoCelValueConverter.java
@@ -154,11 +154,13 @@ public final class ProtoCelValueConverter extends BaseProtoCelValueConverter {
 
         return toRuntimeValue(result);
       case UINT32:
+      case FIXED32:
         if (!fieldDescriptor.isRepeated()) {
           return UnsignedLong.valueOf((int) result);
         }
         break;
       case UINT64:
+      case FIXED64:
         if (!fieldDescriptor.isRepeated()) {
           return UnsignedLong.fromLongBits((long) result);
         }

--- a/common/src/test/java/dev/cel/common/values/ProtoMessageValueTest.java
+++ b/common/src/test/java/dev/cel/common/values/ProtoMessageValueTest.java
@@ -303,6 +303,29 @@ public final class ProtoMessageValueTest {
         .isEqualTo(Duration.ofSeconds(seconds, nanos));
   }
 
+  @Test
+  public void selectField_fixed32_returnsUnsignedLong() {
+    TestAllTypes testAllTypes = TestAllTypes.newBuilder().setSingleFixed32(1).build();
+
+    ProtoMessageValue protoMessageValue =
+        ProtoMessageValue.create(
+            testAllTypes, DefaultDescriptorPool.INSTANCE, PROTO_CEL_VALUE_CONVERTER, false);
+
+    assertThat(protoMessageValue.select("single_fixed32")).isEqualTo(UnsignedLong.valueOf(1L));
+  }
+
+  @Test
+  public void selectField_fixed64_returnsUnsignedLong() {
+    TestAllTypes testAllTypes =
+        TestAllTypes.newBuilder().setSingleFixed64(UnsignedLong.MAX_VALUE.longValue()).build();
+
+    ProtoMessageValue protoMessageValue =
+        ProtoMessageValue.create(
+            testAllTypes, DefaultDescriptorPool.INSTANCE, PROTO_CEL_VALUE_CONVERTER, false);
+
+    assertThat(protoMessageValue.select("single_fixed64")).isEqualTo(UnsignedLong.MAX_VALUE);
+  }
+
   @SuppressWarnings("ImmutableEnumChecker") // Test only
   private enum SelectFieldJsonValueTestCase {
     NULL(Value.newBuilder().build(), NullValue.NULL_VALUE),


### PR DESCRIPTION
The CEL spec maps proto fixed32/fixed64 to CEL's uint. The CelValue path via ProtoCelValueConverter.fromProtoMessageFieldToCelValue lacks FIXED32/FIXED64 and falls through to normalizePrimitive, producing Integer/Long. Overload resolution at runtime then failed with "No matching overload" when the checker said uint but the runtime served a signed integer.

Add the missing case labels alongside UINT32/UINT64 and extend the ProtoMessageValue test suite to cover fixed32/fixed64 selection.